### PR TITLE
Allow arbitrary Huff compiler arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "huff-deployer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Hardhat Plugin To Test Huff Contracts",
   "repository": "github:rodrigoherrerai/huff-deployer",
   "author": "Rodrigo Herrera I.",

--- a/src/HuffDeployer.ts
+++ b/src/HuffDeployer.ts
@@ -1,8 +1,7 @@
 import { Contract, Signer } from "ethers";
 import { ProviderWrapper } from "hardhat/internal/core/providers/wrapper";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
-
-import { deploy } from "./helpers";
+import { CompilerArg, deploy } from "./helpers";
 
 /**
  * HuffDeployer - Hardhat plugin for deploying Huff contracts.
@@ -15,6 +14,7 @@ export class HuffDeployer {
    *
    * @param targetContract The name of the huff contract to deploy.
    * @param constructorArgs The constructor arguments for the contract.
+   * @param compilerArgs Optionally specify arguments to pass to the huff compiler
    * @param signer The signer to use for the deployment.
    *               It left undefined, the signer 0 from Hardhat will be used.
    *
@@ -24,6 +24,7 @@ export class HuffDeployer {
     targetContract: string,
     generateSolidityInterface?: boolean,
     constructorArgs?: any[],
+    compilerArgs?: CompilerArg[],
     signer?: Signer
   ): Promise<Contract> {
     if (signer === undefined) {
@@ -39,7 +40,8 @@ export class HuffDeployer {
       targetContract,
       signer,
       generateInterface,
-      constructorArgs
+      constructorArgs,
+      compilerArgs
     );
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,8 +10,8 @@ import { HuffDeployer } from "./HuffDeployer";
  * Describes an argument to be passed to the Huff compiler
  */
 export interface CompilerArg {
-  key: number;
-  value: number;
+  key: string;
+  value: string;
   full: boolean;
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,14 @@ import { HardhatPluginError } from "hardhat/plugins";
 import { HuffDeployer } from "./HuffDeployer";
 
 /**
+ * Describes an argument to be passed to the Huff compiler
+ */
+export interface CompilerArg {
+  key: number;
+  value: number;
+}
+
+/**
  * Verifies that the Huff compiler (Rust version) is installed.
  */
 async function verifyHuffCompiler(): Promise<void> {
@@ -33,27 +41,42 @@ async function verifyHuffCompiler(): Promise<void> {
 
 /**
  * @param filePath The path to the file where the contract is located.
+ * @param constructorArgs The arguments to pass to the contract constructor
+ * @param compilerArgs Optionally specify arguments to pass to the huff compiler
  * @returns The contract bytecode.
  */
 async function getContractBytecode(
   filePath: string,
-  constructorArgs?: any[]
+  constructorArgs?: any[],
+  compilerArgs?: CompilerArg[]
 ): Promise<string> {
   const output: string = await new Promise((resolve, reject) => {
     let process: ChildProcess;
 
+    let argString = "";
+
+    if (compilerArgs) {
+      argString = " ";
+      for (const arg of compilerArgs) {
+        argString = argString + ` -${arg.key} ${arg.value}`;
+      }
+    }
+
     if (constructorArgs === undefined) {
-      process = exec(`huffc ${filePath} --bytecode`, (err, stdout) => {
-        if (err !== null) {
-          return reject(err);
+      process = exec(
+        `huffc ${filePath} --bytecode${argString}`,
+        (err, stdout) => {
+          if (err !== null) {
+            return reject(err);
+          }
+          resolve(stdout);
         }
-        resolve(stdout);
-      });
+      );
     } else {
       const args = constructorArgs.join(" ");
 
       process = exec(
-        `huffc ${filePath} -i ${args} --bytecode`,
+        `huffc ${filePath} -i ${args} --bytecode${argString}`,
         (err, stdout) => {
           if (err !== null) {
             return reject(err);
@@ -157,7 +180,8 @@ export async function deploy(
   targetContract: string,
   signer: Signer,
   generateInterface: boolean,
-  constructorArgs?: any[]
+  constructorArgs?: any[],
+  compilerArgs?: CompilerArg[]
 ): Promise<Contract> {
   await verifyHuffCompiler();
 
@@ -172,7 +196,11 @@ export async function deploy(
     );
 
     if (targetContract.toLowerCase() === contractName.toLowerCase()) {
-      const bytecode = await getContractBytecode(filePath, constructorArgs);
+      const bytecode = await getContractBytecode(
+        filePath,
+        constructorArgs,
+        compilerArgs
+      );
 
       // We auto generate  the contract interface.
       await generateContractInterface(filePath);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -12,6 +12,7 @@ import { HuffDeployer } from "./HuffDeployer";
 export interface CompilerArg {
   key: number;
   value: number;
+  full: boolean;
 }
 
 /**
@@ -58,7 +59,8 @@ async function getContractBytecode(
     if (compilerArgs) {
       argString = " ";
       for (const arg of compilerArgs) {
-        argString = argString + ` -${arg.key} ${arg.value}`;
+        const key = arg.full ? `--${arg.key}` : `-${arg.key}`;
+        argString = argString + ` ${key} ${arg.value}`;
       }
     }
 


### PR DESCRIPTION
Allow a user to specify arbitrary arguments to be passed to the huff compiler.